### PR TITLE
Fix typo in contact email

### DIFF
--- a/pages/contact.js
+++ b/pages/contact.js
@@ -105,10 +105,10 @@ export default function Contact() {
               <li>
                 📧 Email:{' '}
                 <a
-                  href="mailto:bluewiseai@ptoton.me"
+                  href="mailto:bluewiseai@proton.me"
                   className="text-primary hover:underline"
                 >
-                  bluewiseai@ptoton.me
+                  bluewiseai@proton.me
                 </a>
               </li>
               <li>


### PR DESCRIPTION
## Summary
- fix email address in the English contact page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f81983dd88322bb00d67189a062fd